### PR TITLE
Fixed parsing when no white char before amount/size of the dish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+# PyCharm files
+.idea/

--- a/sks.py
+++ b/sks.py
@@ -20,8 +20,8 @@ if data:
         if (l[1] == 'groupname'): # nice headers
             print ("\n    "+l[2]+"\n    ---")
         else:
-            danie = l[2].split(' ')
-            print ("    {:<36} {:<5}{:>5}".format(u' '.join(danie[:-1]), danie[-1], l[3]))
+            first_num_pos = next(re.finditer('\d+', l[2], )).regs[0][0]
+            print ("    {:<38} {:<10}{:>5}".format(l[2][:first_num_pos], l[2][first_num_pos:], l[3]))
 else:
     print ("Stołówka jest zamknięta :(")
 


### PR DESCRIPTION
I fixed a problem, when name of a dish is not separated from amount or size of the dish by any white character.

Explanation of the problem: [out.txt](https://github.com/pawelabrams/pwr-sks-cli/files/519700/out.txt)

Site causing the problem: [site.txt](https://github.com/pawelabrams/pwr-sks-cli/files/519704/site.txt)
